### PR TITLE
Arguments as hash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+node_modules/

--- a/src/backbone.routefilter.js
+++ b/src/backbone.routefilter.js
@@ -84,7 +84,7 @@
 
         // If the before callback fails during its execusion (by returning)
         // false, then do not proceed with the route triggering.
-        if ( beforeCallback.call(this, callbackArgs) === false ) {
+        if ( beforeCallback.apply(this, callbackArgs) === false ) {
           return;
         }
 
@@ -93,7 +93,7 @@
         // callback function is supplied to handle a given route.
 
         if( callback ) {
-          callback.call( this, arguments_as_hash );
+          callback.apply( this, arguments_as_hash );
         }
 
         var afterCallback;
@@ -117,7 +117,7 @@
         }
 
         // Call the after filter.
-        afterCallback.call( this, callbackArgs );
+        afterCallback.apply( this, callbackArgs );
 
       }, this);
 

--- a/src/backbone.routefilter.js
+++ b/src/backbone.routefilter.js
@@ -84,7 +84,7 @@
 
         // If the before callback fails during its execusion (by returning)
         // false, then do not proceed with the route triggering.
-        if ( beforeCallback.apply(this, callbackArgs) === false ) {
+        if ( beforeCallback.call(this, callbackArgs) === false ) {
           return;
         }
 
@@ -93,7 +93,7 @@
         // callback function is supplied to handle a given route.
 
         if( callback ) {
-          callback.apply( this, arguments_as_hash );
+          callback.call( this, arguments_as_hash );
         }
 
         var afterCallback;
@@ -117,7 +117,7 @@
         }
 
         // Call the after filter.
-        afterCallback.apply( this, callbackArgs );
+        afterCallback.call( this, callbackArgs );
 
       }, this);
 

--- a/src/backbone.routefilter.js
+++ b/src/backbone.routefilter.js
@@ -48,7 +48,21 @@
         // the user to return false from within the before filter
         // to prevent the original route callback and after
         // filter from running.
-        var callbackArgs = [ route, _.toArray(arguments) ];
+
+        // Determine the keys in route
+        var regex = /:([a-zA-Z])*/g;
+        var match, keys = [];
+        while(match = regex.exec(route)) {
+          keys.push(match[0].substr(1));
+        }
+
+        // Build a hash of the key/value argument pairs
+        var arguments_as_hash = {};
+        for (var i = 0; i < arguments.length; i++) {
+          arguments_as_hash[keys[i]] = arguments[i];
+        }
+
+        var callbackArgs = [ route, arguments_as_hash ];
         var beforeCallback;
 
         if ( _.isFunction(this.before) ) {
@@ -77,8 +91,9 @@
         // If the callback exists, then call it. This means that the before
         // and after filters will be called whether or not an actual
         // callback function is supplied to handle a given route.
+
         if( callback ) {
-          callback.apply( this, arguments );
+          callback.apply( this, arguments_as_hash );
         }
 
         var afterCallback;

--- a/src/backbone.routefilter.js
+++ b/src/backbone.routefilter.js
@@ -62,7 +62,7 @@
           arguments_as_hash[keys[i]] = arguments[i];
         }
 
-        var callbackArgs = [ route, arguments_as_hash ];
+        var callbackArgs = {route: route, args: arguments_as_hash};
         var beforeCallback;
 
         if ( _.isFunction(this.before) ) {
@@ -84,7 +84,7 @@
 
         // If the before callback fails during its execusion (by returning)
         // false, then do not proceed with the route triggering.
-        if ( beforeCallback.apply(this, callbackArgs) === false ) {
+        if ( beforeCallback.call(this, callbackArgs.route, callbackArgs.args) === false ) {
           return;
         }
 
@@ -93,7 +93,7 @@
         // callback function is supplied to handle a given route.
 
         if( callback ) {
-          callback.apply( this, arguments_as_hash );
+          callback.call(this, callbackArgs.route, callbackArgs.args);
         }
 
         var afterCallback;
@@ -117,7 +117,7 @@
         }
 
         // Call the after filter.
-        afterCallback.apply( this, callbackArgs );
+        afterCallback.call(this, callbackArgs.route, callbackArgs.args);
 
       }, this);
 


### PR DESCRIPTION
Related to #12

It could be more reliable to pass arguments to the before and after callbacks as a hash. This way, a user wishing to refer to these arguments does not need to rely on the order being correct to access the correct argument. (The order could be unreliable).

@boazsender I did not write any tests; I tried npm install and tried to use grunt to run through the tests, which led to this output:

```
Running "lint:files" (lint) task
Lint free.

Running "qunit:files" (qunit) task
Testing backbone.routefilter.html
events.js:72
        throw er; // Unhandled 'error' event
              ^
Error: spawn ENOENT
    at errnoException (child_process.js:980:11)
    at Process.ChildProcess._handle.onexit (child_process.js:771:34)

```

I figured I would first open the pull request to discuss the merits of this change, and if it's a good change, look into tests after.
